### PR TITLE
Replace compressed hero artwork with a balanced responsive AI visual

### DIFF
--- a/site/assets/hero-ai-control-neon.svg
+++ b/site/assets/hero-ai-control-neon.svg
@@ -1,34 +1,38 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 680" role="img" aria-labelledby="t d">
-<title id="t">Secure AI platform</title><desc id="d">A layered secure AI platform connecting governance, security, automation and business value.</desc>
-<defs>
-  <linearGradient id="blue" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#60A5FA"/><stop offset=".48" stop-color="#2563EB"/><stop offset="1" stop-color="#1D4ED8"/></linearGradient>
-  <linearGradient id="navy" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#173A72"/><stop offset="1" stop-color="#0B132B"/></linearGradient>
-  <linearGradient id="glass" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#FFFFFF" stop-opacity=".96"/><stop offset="1" stop-color="#DBEAFE" stop-opacity=".72"/></linearGradient>
-  <filter id="shadow" x="-30%" y="-30%" width="160%" height="180%"><feDropShadow dx="0" dy="24" stdDeviation="24" flood-color="#1D4ED8" flood-opacity=".18"/></filter>
-  <filter id="soft" x="-30%" y="-30%" width="160%" height="160%"><feGaussianBlur stdDeviation="14"/></filter>
-  <pattern id="grid" width="38" height="38" patternUnits="userSpaceOnUse"><path d="M38 0H0v38" fill="none" stroke="#2563EB" stroke-opacity=".08"/></pattern>
-</defs>
-<rect width="900" height="680" fill="white" fill-opacity="0"/>
-<ellipse cx="560" cy="585" rx="270" ry="42" fill="#2563EB" opacity=".1" filter="url(#soft)"/>
-<path d="M140 546 500 350l285 155-360 196Z" fill="url(#grid)" opacity=".7"/>
-<g filter="url(#shadow)">
-  <path d="M300 470 545 335l198 108-246 136Z" fill="url(#navy)" stroke="#93C5FD" stroke-width="3"/>
-  <path d="M300 470v48l197 108 246-136v-47L497 578Z" fill="#0B2149" opacity=".98"/>
-  <path d="M328 381 544 263l174 95-216 119Z" fill="url(#blue)" stroke="#BFDBFE" stroke-width="3"/>
-  <path d="M328 381v43l174 95 216-119v-42L502 477Z" fill="#17499B"/>
-  <path d="M361 300 543 200l147 80-183 101Z" fill="url(#glass)" stroke="#93C5FD" stroke-width="3"/>
-  <path d="M361 300v38l146 80 183-100v-38L507 381Z" fill="#DCEBFF" fill-opacity=".82"/>
-</g>
-<g opacity=".9" stroke="#2563EB" stroke-width="3" fill="none">
-  <path d="M404 318 468 353l74-41 62 34"/>
-  <path d="M423 299 488 334l70-39"/>
-  <circle cx="404" cy="318" r="7" fill="#fff"/><circle cx="468" cy="353" r="7" fill="#fff"/><circle cx="542" cy="312" r="7" fill="#fff"/><circle cx="604" cy="346" r="7" fill="#fff"/><circle cx="423" cy="299" r="7" fill="#fff"/><circle cx="488" cy="334" r="7" fill="#fff"/><circle cx="558" cy="295" r="7" fill="#fff"/>
-</g>
-<g transform="translate(471 74)" filter="url(#shadow)">
-  <path d="M78 0 150 30v63c0 62-30 106-72 132C36 199 6 155 6 93V30Z" fill="url(#glass)" stroke="#93C5FD" stroke-width="4"/>
-  <path d="M78 20 130 42v49c0 44-20 76-52 98-32-22-52-54-52-98V42Z" fill="url(#blue)"/>
-  <path d="m48 95 21 20 40-48" fill="none" stroke="#DDFBFF" stroke-width="11" stroke-linecap="round" stroke-linejoin="round"/>
-</g>
-<g fill="#2563EB" opacity=".22"><circle cx="700" cy="160" r="6"/><circle cx="735" cy="205" r="4"/><circle cx="240" cy="420" r="5"/><circle cx="210" cy="462" r="3"/></g>
-<g stroke="#60A5FA" stroke-opacity=".35" fill="none"><path d="M690 132h95v95"/><path d="M205 390h-70v95"/><rect x="255" y="218" width="465" height="324" rx="28"/></g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 720" preserveAspectRatio="xMidYMid meet" role="img" aria-labelledby="title desc">
+  <title id="title">Secure and governed AI operating system</title>
+  <desc id="desc">A balanced visual showing governance, security and automation layers connected to people, data, oversight and business value.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#F8FBFF"/><stop offset="1" stop-color="#EEF5FF"/></linearGradient>
+    <linearGradient id="blue" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#38BDF8"/><stop offset=".45" stop-color="#2563EB"/><stop offset="1" stop-color="#1D4ED8"/></linearGradient>
+    <linearGradient id="teal" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#5EEAD4"/><stop offset=".55" stop-color="#0F9F8F"/><stop offset="1" stop-color="#0F766E"/></linearGradient>
+    <linearGradient id="violet" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#C4B5FD"/><stop offset=".48" stop-color="#7C3AED"/><stop offset="1" stop-color="#5B21B6"/></linearGradient>
+    <linearGradient id="orange" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#FDBA74"/><stop offset="1" stop-color="#F97316"/></linearGradient>
+    <linearGradient id="glass" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#FFFFFF" stop-opacity=".96"/><stop offset="1" stop-color="#E8F2FF" stop-opacity=".78"/></linearGradient>
+    <linearGradient id="navy" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#173A72"/><stop offset="1" stop-color="#0B132B"/></linearGradient>
+    <radialGradient id="halo"><stop stop-color="#60A5FA" stop-opacity=".34"/><stop offset=".5" stop-color="#38BDF8" stop-opacity=".13"/><stop offset="1" stop-color="#2563EB" stop-opacity="0"/></radialGradient>
+    <pattern id="grid" width="36" height="36" patternUnits="userSpaceOnUse"><path d="M36 0H0v36" fill="none" stroke="#2563EB" stroke-opacity=".07"/></pattern>
+    <filter id="soft" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="22"/></filter>
+  </defs>
+  <rect x="24" y="22" width="912" height="676" rx="54" fill="url(#bg)"/>
+  <rect x="24" y="22" width="912" height="676" rx="54" fill="url(#grid)" opacity=".62"/>
+  <ellipse cx="508" cy="365" rx="310" ry="265" fill="url(#halo)"/>
+  <ellipse cx="510" cy="618" rx="275" ry="48" fill="#2563EB" opacity=".12" filter="url(#soft)"/>
+  <g opacity=".52" stroke="#60A5FA" stroke-width="2.5" stroke-dasharray="7 10" fill="none"><path d="M197 182C284 118 370 126 440 190"/><path d="M760 182C680 116 592 128 530 194"/><path d="M160 473C245 548 323 564 405 528"/><path d="M798 471C704 552 627 565 548 530"/></g>
+  <g>
+    <g transform="translate(112 123)"><circle cx="54" cy="54" r="47" fill="#FFFFFF" stroke="#BFDBFE" stroke-width="3"/><circle cx="54" cy="54" r="31" fill="#EEF5FF"/><path d="M42 53h24M42 43h24M42 63h16" stroke="#2563EB" stroke-width="5" stroke-linecap="round"/><circle cx="72" cy="64" r="7" fill="url(#orange)"/></g>
+    <g transform="translate(743 123)"><circle cx="54" cy="54" r="47" fill="#FFFFFF" stroke="#CCFBF1" stroke-width="3"/><circle cx="54" cy="54" r="31" fill="#ECFEFF"/><circle cx="54" cy="45" r="10" fill="none" stroke="#0F9F8F" stroke-width="5"/><path d="M36 72c4-13 14-19 18-19s14 6 18 19" fill="none" stroke="#0F9F8F" stroke-width="5" stroke-linecap="round"/></g>
+    <g transform="translate(96 472)"><circle cx="54" cy="54" r="47" fill="#FFFFFF" stroke="#DDD6FE" stroke-width="3"/><circle cx="54" cy="54" r="31" fill="#F5F3FF"/><path d="M38 43h32v24H38z" fill="none" stroke="#7C3AED" stroke-width="5"/><path d="M44 50h20M44 58h13" stroke="#7C3AED" stroke-width="4" stroke-linecap="round"/></g>
+    <g transform="translate(760 470)"><circle cx="54" cy="54" r="47" fill="#FFFFFF" stroke="#FED7AA" stroke-width="3"/><circle cx="54" cy="54" r="31" fill="#FFF7ED"/><path d="M38 68V50m12 18V38m12 30V45m12 23V31" stroke="#F97316" stroke-width="5" stroke-linecap="round"/><path d="M35 70h43" stroke="#F97316" stroke-width="4" stroke-linecap="round"/></g>
+  </g>
+  <g opacity=".75" stroke-width="4" fill="none" stroke-linecap="round"><path d="M213 194 358 274" stroke="#2563EB"/><path d="M747 194 604 274" stroke="#0F9F8F"/><path d="M203 515 350 466" stroke="#7C3AED"/><path d="M758 515 614 466" stroke="#F97316"/></g>
+  <g>
+    <path d="M285 454 500 570 716 451 501 336Z" fill="url(#navy)" stroke="#93C5FD" stroke-width="3"/><path d="M285 454v55l215 116 216-119v-55L501 570Z" fill="#0B2149"/>
+    <path d="M314 367 500 467 687 364 501 265Z" fill="url(#violet)" stroke="#DDD6FE" stroke-width="3"/><path d="M314 367v48l186 101 187-103v-49L501 467Z" fill="#5B21B6" opacity=".94"/>
+    <path d="M347 288 500 370 654 285 501 203Z" fill="url(#teal)" stroke="#99F6E4" stroke-width="3"/><path d="M347 288v43l153 83 154-85v-44L501 370Z" fill="#0F766E" opacity=".94"/>
+    <path d="M385 215 500 277 617 212 501 151Z" fill="url(#glass)" stroke="#93C5FD" stroke-width="3"/><path d="M385 215v37l115 62 117-65v-37L501 277Z" fill="#DCEBFF" fill-opacity=".92"/>
+  </g>
+  <g opacity=".95" stroke="#2563EB" stroke-width="4" fill="none" stroke-linecap="round"><path d="M424 223 466 246l39-22 42 22 35-20"/><path d="M448 202 488 224l35-19"/><circle cx="424" cy="223" r="7" fill="#fff"/><circle cx="466" cy="246" r="7" fill="#fff"/><circle cx="505" cy="224" r="7" fill="#fff"/><circle cx="547" cy="246" r="7" fill="#fff"/><circle cx="582" cy="226" r="7" fill="#fff"/><circle cx="448" cy="202" r="7" fill="#fff"/><circle cx="488" cy="224" r="7" fill="#fff"/><circle cx="523" cy="205" r="7" fill="#fff"/></g>
+  <g transform="translate(417 66)"><path d="M83 0 162 33v69c0 68-33 116-79 145C37 218 4 170 4 102V33Z" fill="url(#glass)" stroke="#93C5FD" stroke-width="5"/><path d="M83 22 141 47v54c0 49-23 84-58 108-35-24-58-59-58-108V47Z" fill="url(#blue)"/><path d="m50 105 23 22 45-53" fill="none" stroke="#E6FFFB" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/><circle cx="135" cy="52" r="8" fill="url(#orange)"/></g>
+  <g fill="#FFFFFF" stroke="#BFDBFE" stroke-width="2"><circle cx="355" cy="274" r="7"/><circle cx="606" cy="274" r="7"/><circle cx="351" cy="466" r="7"/><circle cx="613" cy="466" r="7"/></g>
+  <g opacity=".36" fill="#2563EB"><circle cx="282" cy="146" r="6"/><circle cx="698" cy="146" r="5"/><circle cx="256" cy="572" r="4"/><circle cx="704" cy="570" r="6"/></g>
 </svg>


### PR DESCRIPTION
Replaces the shared homepage hero SVG used by English, Danish and Swedish with a wider, better-balanced illustration. The new visual fills its canvas instead of leaving large transparent gutters, uses an explicit 4:3 viewBox with preserveAspectRatio, and presents governance, security and automation layers connected to people, policy, information and business value. It uses SundAI's blue, turquoise, violet and orange accents, remains fully local and vector-based, adds no network requests, and preserves the existing HTML, copy, SEO and mobile performance behaviour.